### PR TITLE
Web IDE내에서 파일 생성/삭제/수정 관련 기능 구현

### DIFF
--- a/src/main/java/com/ssap/SSAPIDE/controller/FileController.java
+++ b/src/main/java/com/ssap/SSAPIDE/controller/FileController.java
@@ -1,0 +1,50 @@
+package com.ssap.SSAPIDE.controller;
+
+import com.ssap.SSAPIDE.dto.FileAndFolderCreateRequestDto;
+import com.ssap.SSAPIDE.service.FileAndFolderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RestController
+@RequestMapping("/ide/{containerId}/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileAndFolderService fileAndFolderService;
+
+    @PostMapping
+    public ResponseEntity<?> createFile(@PathVariable String containerId,
+                                          @Valid @RequestBody FileAndFolderCreateRequestDto requestDto) {
+        try {
+            requestDto.setContainerId(containerId);
+            String createdName = fileAndFolderService.createFileOrFolder(requestDto);
+
+            return ResponseEntity.status(201).body(
+                    Map.of("status", 201,
+                            "message", "파일 생성 성공"));
+        } catch (IllegalArgumentException e) {
+            log.error("Error due to illegal argument: {}", e.getMessage());
+            return ResponseEntity.status(400).body(Map.of("status", 400, "message", "파라미터 필수 항목이 누락되었거나 형식이 잘못되었습니다."));
+        } catch (SecurityException e) {
+            log.error("Error due to security constraints: {}", e.getMessage());
+            return ResponseEntity.status(403).body(Map.of("status", 403, "message", "해당 경로에 파일을 생성할 권한이 없습니다."));
+        } catch (NoSuchElementException e) {
+            log.error("Error due to non-existent element: {}", e.getMessage());
+            return ResponseEntity.status(404).body(Map.of("status", 404, "message", "지정된 containerId에 해당하는 컨테이너가 존재하지 않습니다."));
+        } catch (Exception e) {
+            log.error("Error while creating file or folder: {}", e.getMessage());
+            if (e.getMessage().contains("Conflict")) {
+                return ResponseEntity.status(409).body(Map.of("status", 409, "message", "동일한 이름의 파일이 이미 해당 경로에 존재합니다."));
+            } else {
+                return ResponseEntity.status(500).body(Map.of("status", 500, "message", "요청을 처리하는 중에 서버에서 오류가 발생했습니다."));
+            }
+        }
+    }
+}

--- a/src/main/java/com/ssap/SSAPIDE/controller/FileController.java
+++ b/src/main/java/com/ssap/SSAPIDE/controller/FileController.java
@@ -1,6 +1,7 @@
 package com.ssap.SSAPIDE.controller;
 
 import com.ssap.SSAPIDE.dto.FileAndFolderCreateRequestDto;
+import com.ssap.SSAPIDE.dto.FileRenameRequestDto;
 import com.ssap.SSAPIDE.service.FileAndFolderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,27 @@ public class FileController {
             } else {
                 return ResponseEntity.status(500).body(Map.of("status", 500, "message", "요청을 처리하는 중에 서버에서 오류가 발생했습니다."));
             }
+        }
+    }
+
+    @DeleteMapping("/{fileId}")
+    public ResponseEntity<Map<String, String>> deleteFile(@PathVariable String containerId, @PathVariable Long fileId) {
+        try {
+            fileAndFolderService.deleteFile(containerId, fileId);
+
+            return ResponseEntity.ok(Map.of("message", "파일 삭제 완료"));
+        } catch (IllegalArgumentException e) {
+            log.error("Error due to illegal argument: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of("message", "파라미터 필수 항목이 누락되었거나 형식이 잘못되었습니다."));
+        } catch (SecurityException e) {
+            log.error("Error due to security constraints: {}", e.getMessage());
+            return ResponseEntity.status(403).body(Map.of("message", "해당 파일을 삭제할 권한이 없습니다."));
+        } catch (NoSuchElementException e) {
+            log.error("Error due to non-existent element: {}", e.getMessage());
+            return ResponseEntity.status(404).body(Map.of("message", "지정된 경로에 해당하는 파일이 존재하지 않습니다."));
+        } catch (Exception e) {
+            log.error("Error while deleting file: {}", e.getMessage());
+            return ResponseEntity.status(500).body(Map.of("message", "요청을 처리하는 중에 서버에서 오류가 발생했습니다."));
         }
     }
 }

--- a/src/main/java/com/ssap/SSAPIDE/dto/FileRenameRequestDto.java
+++ b/src/main/java/com/ssap/SSAPIDE/dto/FileRenameRequestDto.java
@@ -1,0 +1,12 @@
+package com.ssap.SSAPIDE.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FileRenameRequestDto {
+    @NotBlank
+    private String newFileName;
+}

--- a/src/main/java/com/ssap/SSAPIDE/model/FileAndFolder.java
+++ b/src/main/java/com/ssap/SSAPIDE/model/FileAndFolder.java
@@ -24,6 +24,7 @@ public class FileAndFolder {
     private Long parentFolderId; // 부모 폴더Id
     private String name;  // 폴더 또는 파일명
     private Boolean type; // true: 파일, false: 폴더
+    private String ext;
     private String content; // 파일 내용
     private LocalDateTime lastModified; // 수정 시간
     private String path; // 파일 또는 폴더의 경로

--- a/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
+++ b/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
@@ -84,4 +84,22 @@ public class FileAndFolderService {
         }
     }
 
+    public void renameFile(String containerId, Long folderId, String newFolderName) {
+        Optional<FileAndFolder> optionalFolder = fileAndFolderRepository.findById(folderId);
+        if (optionalFolder.isPresent()) {
+            FileAndFolder folderToRename = optionalFolder.get();
+            if (!folderToRename.getContainer().getContainerId().equals(containerId)) {
+                throw new SecurityException("동일한 이름의 파일이 이미 해당 경로에 존재합니다.");
+            }
+
+            if (fileAndFolderRepository.existsByNameAndPath(newFolderName, folderToRename.getPath())) {
+                throw new SecurityException("동일한 이름의 파일이 이미 해당 경로에 존재합니다.");
+            }
+
+            folderToRename.setName(newFolderName);
+            fileAndFolderRepository.save(folderToRename);
+        } else {
+            throw new NoSuchElementException("지정된 경로에 해당하는 파일이 존재하지 않습니다.");
+        }
+    }
 }

--- a/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
+++ b/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
@@ -26,7 +26,7 @@ public class FileAndFolderService {
         fileAndFolder.setParentFolderId(dto.getParentFolderId());
         fileAndFolder.setName(dto.getName());
         fileAndFolder.setType(dto.getType());
-        
+
         if (dto.getType()) { // 파일인 경우
             fileAndFolder.setContent(dto.getContent());
             fileAndFolder.setExt(dto.getExt());
@@ -70,4 +70,18 @@ public class FileAndFolderService {
             throw new NoSuchElementException("지정된 경로에 해당하는 폴더가 존재하지 않습니다.");
         }
     }
+
+    public void deleteFile(String containerId, Long folderId) {
+        Optional<FileAndFolder> optionalFolder = fileAndFolderRepository.findById(folderId);
+        if (optionalFolder.isPresent()) {
+            FileAndFolder folderToDelete = optionalFolder.get();
+            if (!folderToDelete.getContainer().getContainerId().equals(containerId)) {
+                throw new SecurityException("해당 파일를 삭제할 권한이 없습니다.");
+            }
+            fileAndFolderRepository.delete(folderToDelete);
+        } else {
+            throw new NoSuchElementException("지정된 경로에 해당하는 파일이 존재하지 않습니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
+++ b/src/main/java/com/ssap/SSAPIDE/service/FileAndFolderService.java
@@ -26,7 +26,12 @@ public class FileAndFolderService {
         fileAndFolder.setParentFolderId(dto.getParentFolderId());
         fileAndFolder.setName(dto.getName());
         fileAndFolder.setType(dto.getType());
-        fileAndFolder.setContent(dto.getContent());
+        
+        if (dto.getType()) { // 파일인 경우
+            fileAndFolder.setContent(dto.getContent());
+            fileAndFolder.setExt(dto.getExt());
+        }
+
         fileAndFolder.setLastModified(LocalDateTime.now());
         fileAndFolder.setPath(dto.getPath());
 


### PR DESCRIPTION
## 요약
- Web IDE내에서 파일 생성/삭제/수정 관련 기능 구현
## 변경 내용
- Web IDE내에서 파일 생성/삭제/수정 기능 추가
-  파일 생성 및 폴더 생성 서비스 로직 수정 
 - type을 체크하여 파일인 경우(type이 true) content(내용), ext(확장자)을 DB에 저장하도록 수정
## 이슈 번호 또는 링크
#22 #23 #25 #41 